### PR TITLE
fix: restest: query params support

### DIFF
--- a/pkg/restest/test_manager.go
+++ b/pkg/restest/test_manager.go
@@ -132,7 +132,7 @@ func (m *TestManager) exec() {
 	// find the handler for the given path
 
 	if m.handler == nil {
-		e.Router().Find(m.method, m.path, c)
+		e.Router().Find(m.method, req.URL.Path, c)
 		m.handler = c.Handler()
 	}
 


### PR DESCRIPTION
- [X] Provide the Path that does not include the query portion of the URL for params processing.


## What was going on?

When using `CallsPath` with query params in the end, if the last portion of the non-queryparam URL ended in a URLParam, then that URLParam would be combined with the query params in question (nooooo). This solves it.